### PR TITLE
Add manual point assignment plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # discourse-point-assign
+
+This plugin provides an admin interface to manually grant gamification points to users.
+
+* Accessible only to admin users.
+* Points are added to `gamification_scores` and recorded in `gamification_score_events` with description set to `manual`.
+* A small form allows entering the user ID, point amount, and reason.
+* Success or failure is displayed via alert after submission.

--- a/plugins/manual_points/app/assets/javascripts/point-assign.js
+++ b/plugins/manual_points/app/assets/javascripts/point-assign.js
@@ -1,0 +1,20 @@
+(function() {
+  const form = document.getElementById('manual-points-form');
+  if (!form) { return; }
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const data = new FormData(form);
+    fetch('/admin/point-assign', {
+      method: 'POST',
+      headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content },
+      body: data
+    }).then(r => {
+      if (r.ok) {
+        alert('Points granted');
+        form.reset();
+      } else {
+        r.json().then(j => alert(j.error || 'Error'));
+      }
+    });
+  });
+})();

--- a/plugins/manual_points/app/controllers/manual_points_controller.rb
+++ b/plugins/manual_points/app/controllers/manual_points_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DiscoursePointAssign
+  class ManualPointsController < ::Admin::AdminController
+    requires_plugin PLUGIN_NAME
+
+    def index
+    end
+
+    def create
+      user = User.find_by(id: params[:user_id])
+      points = params[:points].to_i
+      reason = params[:reason]
+      if user && points != 0
+        score = GamificationScore.find_or_create_by(user_id: user.id, date: Date.today)
+        score.score += points
+        score.save!
+        GamificationScoreEvent.create!(
+          user_id: user.id,
+          date: Date.today,
+          points: points,
+          description: 'manual',
+          reason: reason
+        )
+        render json: success_json
+      else
+        render json: { error: I18n.t('manual_points.error') }, status: 422
+      end
+    end
+  end
+end

--- a/plugins/manual_points/app/views/discourse_point_assign/manual_points/index.html.erb
+++ b/plugins/manual_points/app/views/discourse_point_assign/manual_points/index.html.erb
@@ -1,0 +1,17 @@
+<div class="manual-points">
+  <form id="manual-points-form">
+    <div>
+      <label>User ID:</label>
+      <input type="number" name="user_id" required>
+    </div>
+    <div>
+      <label>Points:</label>
+      <input type="number" name="points" required>
+    </div>
+    <div>
+      <label>Reason:</label>
+      <input type="text" name="reason" required>
+    </div>
+    <button type="submit">Grant Points</button>
+  </form>
+</div>

--- a/plugins/manual_points/config/locales/server.en.yml
+++ b/plugins/manual_points/config/locales/server.en.yml
@@ -1,0 +1,3 @@
+en:
+  manual_points:
+    error: "Invalid user or points"

--- a/plugins/manual_points/config/settings.yml
+++ b/plugins/manual_points/config/settings.yml
@@ -1,0 +1,4 @@
+plugins:
+  manual_points_enabled:
+    default: true
+    client: false

--- a/plugins/manual_points/plugin.rb
+++ b/plugins/manual_points/plugin.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# name: discourse-point-assign
+# about: Manual point assignment for Discourse Gamification
+# version: 0.1
+# authors: ChatGPT
+
+enabled_site_setting :manual_points_enabled
+
+PLUGIN_NAME ||= "discourse-point-assign"
+
+after_initialize do
+  module ::DiscoursePointAssign
+    class Engine < ::Rails::Engine
+      engine_name PLUGIN_NAME
+      isolate_namespace DiscoursePointAssign
+    end
+  end
+
+  DiscoursePointAssign::Engine.routes.draw do
+    get "/" => "manual_points#index"
+    post "/" => "manual_points#create"
+  end
+
+  Discourse::Application.routes.append do
+    mount ::DiscoursePointAssign::Engine, at: "/admin/point-assign"
+  end
+
+  register_asset "javascripts/point-assign.js", :admin
+end


### PR DESCRIPTION
## Summary
- create manual points plugin allowing admin to give points with a reason
- add controller and view to update `gamification_scores` and insert score events
- include a basic form and JS to notify success or failure
- document the plugin in README

## Testing
- `ruby -c plugins/manual_points/plugin.rb`
- `ruby -c plugins/manual_points/app/controllers/manual_points_controller.rb`


------
https://chatgpt.com/codex/tasks/task_e_686e2e3b3c18832c8986447feb3a2dba