### PR TITLE
Add admin menu route for manual points

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,4 @@
 en:
   manual_points:
     error: "Invalid user or points"
+    title: "Manual Points"

--- a/plugin.rb
+++ b/plugin.rb
@@ -22,7 +22,9 @@ after_initialize do
     post "/" => "manual_points#create"
   end
 
+  add_admin_route 'manual_points.title', 'manual-points'
+
   Discourse::Application.routes.append do
-    mount ::DiscoursePointAssign::Engine, at: "/admin/manual-points"
+    mount ::DiscoursePointAssign::Engine, at: "/admin/plugins/manual-points"
   end
 end


### PR DESCRIPTION
## Summary
- register admin route and mount under `/admin/plugins`
- add en translation for plugin title

## Testing
- `ruby -c plugin.rb`
- `ruby -c app/controllers/discourse_point_assign/manual_points_controller.rb`
- `ruby -ryaml -e 'YAML.load_file("config/locales/server.en.yml")'`


------
https://chatgpt.com/codex/tasks/task_e_6875a305bce4832c8bd053af6f11e0ee